### PR TITLE
fix API import and syntax warnings

### DIFF
--- a/pyiptmnet/api.py
+++ b/pyiptmnet/api.py
@@ -61,7 +61,7 @@ def search(search_term, term_type, role, ptm_list=None, organism_list=None, dict
 
     result = requests.get(url, params=data, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             search_results = json.loads(result.text)
@@ -78,7 +78,7 @@ def get_info(id, dict=None):
     url = f"{base_url}/{id}/info"
     result = requests.get(url, verify=False)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         info = json.loads(result.text)
         return info
@@ -97,7 +97,7 @@ def get_msa(id,dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -120,7 +120,7 @@ def get_substrates(id, dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -143,7 +143,7 @@ def get_proteoforms(id, dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -166,7 +166,7 @@ def get_ptm_dependent_ppi(id, dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -188,7 +188,7 @@ def get_ppi_for_proteoforms(id, dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -218,7 +218,7 @@ def get_ptm_enzymes_from_list(items,dict=None):
 
     result = requests.post(url, data=json_data, verify=False,headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -247,7 +247,7 @@ def get_ptm_ppi_from_list(items,dict=None):
 
     result = requests.post(url, data=json_data, verify=False,headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)
@@ -269,7 +269,7 @@ def get_variants(id, dict=None):
 
     result = requests.get(url, verify=False, headers=headers)
 
-    if result.status_code is 200:
+    if result.status_code == 200:
         # read the result
         if dict is True:
             data = json.loads(result.text)

--- a/pyiptmnet/api.py
+++ b/pyiptmnet/api.py
@@ -3,7 +3,7 @@ import requests
 import csv
 from io import StringIO
 import pandas
-from pandas.io.json import json_normalize
+from pandas.io.json import _normalize
 import urllib3
 from pyiptmnet.enums import API_VERSION
 
@@ -25,7 +25,7 @@ def _to_dataframe(text):
     return dataframe
 
 def _to_dataframe_from_json(json):
-    dataframe = json_normalize(json)
+    dataframe = _normalize(json)
     return dataframe
 
 def search(search_term, term_type, role, ptm_list=None, organism_list=None, dict=None):


### PR DESCRIPTION
pandas package `pandas.io.json" has changed function "json_normalize" to "_normalize". The initial API import:

```python
import pyiptmnet.api as api
```

is broken because of this. Once fixed there are a bunch of SyntaxWarnings which want `==` instead of `is` for a bunch of lines checking HTTP status codes.